### PR TITLE
Allow dismissing from outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /dist/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # myuw-notifications versions
 
+## 1.3.1
+
+### Fixed
+- Removing notification from DOM when dismissed from outside of the component
+
 ## 1.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ document.addEventListener('myuw-notification-dismissed', (event) => {
 }, false);
 ```
 
+In addition, notifications can be dimissed by dispatching a `myuw-notification-dismissed` event with the field `event.detail.dismissedFromOutside` set to `true`, and `event.detail.notificationId` set to id of the notification you want to dismiss.
+
 ### Configurable attributes
 
 - **see-all-url**: If this optional attribute is provided, the component will display a "See all" link in the title row of the notifications list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-notifications",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-notifications",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Web component that provides an icon button and menu/list of notifications",
   "module": "dist/myuw-notifications.min.mjs",
   "browser": "dist/myuw-notifications.min.js",

--- a/src/myuw-notifications.js
+++ b/src/myuw-notifications.js
@@ -72,6 +72,10 @@ export class MyUWNotifications extends HTMLElement {
             // Remove notification
             var index = this.$notificationIds.indexOf(event.detail.notificationId);
             this.$notificationIds.splice(index, 1);
+            // Remove from DOM, if necessary
+            if (event.detail.dismissedFromOutside) {
+              this.$list.removeChild(this.$list.getElementsByTagName('myuw-notification')[index]);
+            }
             // Update for empty state
             if (this.$notificationIds.length <= 0) {
               this.$emptyState.classList.remove('hidden');


### PR DESCRIPTION
## 1.3.1

### Fixed
- Removing notification from DOM when dismissed from outside of the component
