### PR TITLE
Handle notifications display on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-notifications versions
 
+## 1.3.4
+
+### Added
+- On mobile views, redirect to See-all page, if the link was provided, rather than display the modal.
+- Update modal styles on mobile views, if displayed
+
 ## 1.3.3
 
 ### Fixed

--- a/src/myuw-notifications.html
+++ b/src/myuw-notifications.html
@@ -144,6 +144,17 @@
     width: 525px;
   }
 }
+
+@media all and (max-width: 460px) {
+  #wrapper {
+    position: initial;
+  }
+  #list {
+    top: 4.6em;
+    width: 100%;
+  }
+}
+
 </style>
 
 <div id="wrapper">

--- a/src/myuw-notifications.js
+++ b/src/myuw-notifications.js
@@ -119,7 +119,13 @@ export class MyUWNotifications extends HTMLElement {
             Add an on-click event to the bell button.
         */
       this.$bell.addEventListener('click', e => {
-        this.closeMenu(e);
+
+      // On mobile views, redirect to See-all page, if the link was provided
+      if (window.matchMedia("(max-width: 460px)").matches && this['see-all-url']) {
+        window.history.pushState('notifications', 'Notifications', this['see-all-url']);
+       } else {
+         this.closeMenu(e);
+       }
       });
 
       // Changed to 'keyup' to fix incorrect activeElement reference


### PR DESCRIPTION
## 1.3.4

### Added
- On mobile views, redirect to the See-all page, if the link was provided, rather than display the modal.
- Update modal styles on mobile views, if displayed

Before:
<img width="335" alt="Screen Shot 2020-09-08 at 1 04 15 PM" src="https://user-images.githubusercontent.com/10341961/92512993-3eabdc80-f1d5-11ea-94a4-1802db8f8fac.png">

After:
<img width="333" alt="Screen Shot 2020-09-08 at 1 03 34 PM" src="https://user-images.githubusercontent.com/10341961/92513018-45d2ea80-f1d5-11ea-9180-c9a81d78179e.png">
